### PR TITLE
Save-file indication

### DIFF
--- a/ArchiveExplorer/ArchiveExplorer/MainWindow.xaml.cs
+++ b/ArchiveExplorer/ArchiveExplorer/MainWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace ArchiveExplorer
 {
     public partial class MainWindow : Window
     {
-
+        private bool _saved = true;
         public static readonly string AppTag = "AE";
         public static readonly string Version = "v0.26";
 
@@ -102,6 +102,17 @@ namespace ArchiveExplorer
                     OpenLinkInBrowser(downloadUri);
                 }
             }
+        }
+
+        private void UpdateTitleSaveIndication(bool enabled)
+        {
+            if (this._saved == !enabled) return;
+
+            this._saved = !enabled;
+            if (!this._saved)
+                this.Title = this.Title + "*";
+            else
+                this.Title = this.Title.Substring(0, this.Title.Length - 1);
         }
 
         public struct github_releases
@@ -371,6 +382,7 @@ namespace ArchiveExplorer
             currentNode = currentFile.structure;
             UpdateListView(currentFile.structure);
             UpdatePath();
+            UpdateTitleSaveIndication(true);
         }
 
         private void OpenFile_Click(object sender, RoutedEventArgs e) => OpenFileDialog();
@@ -393,6 +405,7 @@ namespace ArchiveExplorer
             byte[] saveData = currentFile.EncodeARC();
             if(Path.GetExtension(currentFilePath) == ".szs") saveData = YAZ0.Compress(saveData, level);
             File.WriteAllBytes(currentFilePath, saveData);
+            UpdateTitleSaveIndication(false);
         }
 
         private void QuickSave_Click(object sender, RoutedEventArgs e)
@@ -481,6 +494,7 @@ namespace ArchiveExplorer
                 var currentItem = FileView.SelectedItem as FileListItem;
                 if (currentItem == null) return;
                 TryImportFile(file, false, false, currentItem.Text, true);
+                UpdateTitleSaveIndication(true);
             }
         }
 
@@ -493,6 +507,7 @@ namespace ArchiveExplorer
                 {
                     if (file.Contains(currentFile.TemporaryPath)) continue;
                     TryImportFile(file);
+                    UpdateTitleSaveIndication(true);
                 }
             }
         }
@@ -522,6 +537,7 @@ namespace ArchiveExplorer
             }
             UpdateTreeView();
             UpdateListView(currentNode);
+            UpdateTitleSaveIndication(true);
         }
 
         private void TreeViewItem_Drop(object sender, DragEventArgs e) 
@@ -550,6 +566,7 @@ namespace ArchiveExplorer
             }
             UpdateTreeView();
             UpdateListView(currentNode);
+            UpdateTitleSaveIndication(true);
         }
 
 
@@ -695,6 +712,8 @@ namespace ArchiveExplorer
             textBox.Cursor = Cursors.IBeam;
             textBox.BorderThickness = new Thickness(1);
             textBox.SelectAll();
+
+            UpdateTitleSaveIndication(true);
         }
 
         private childItem FindVisualChild<childItem>(DependencyObject obj)
@@ -724,6 +743,7 @@ namespace ArchiveExplorer
             currentFile.ExportNode(node);
             UpdateListView(currentNode);
             UpdateTreeView();
+            UpdateTitleSaveIndication(true);
         }
 
         private void CopyItem_Click(object sender, RoutedEventArgs e)
@@ -762,6 +782,7 @@ namespace ArchiveExplorer
                     currentFile.RemoveNode(item.Node);
                 UpdateListView(currentNode);
                 UpdateTreeView();
+                UpdateTitleSaveIndication(true);
             }
         }
 
@@ -773,6 +794,7 @@ namespace ArchiveExplorer
             {
                 currentFile.RemoveNode(item.Node);
                 UpdateListView(currentNode);
+                UpdateTitleSaveIndication(true);
             }
             UpdateTreeView();
         }
@@ -836,6 +858,7 @@ namespace ArchiveExplorer
             currentFile.RecalculateStructureIndexes();
             UpdateListView(currentNode);
             UpdateTreeView();
+            UpdateTitleSaveIndication(true);
         }
 
         private void TryImportFile(string filepath, bool forceDuplicate = false, bool importARC = true, string originalPath = null, bool forceOverride = false)
@@ -931,6 +954,7 @@ namespace ArchiveExplorer
             currentFile.UpdateAllNodeData();
             UpdateListView(currentNode);
             UpdateTreeView();
+            UpdateTitleSaveIndication(true);
         }
         
         private void TryOpenFile(string filepath)
@@ -966,6 +990,7 @@ namespace ArchiveExplorer
             UpdateListView(currentFile.structure);
             currentNode = currentFile.structure;
             UpdatePath();
+            UpdateTitleSaveIndication(false);
         }
 
 
@@ -1124,7 +1149,7 @@ namespace ArchiveExplorer
 
         protected override void OnClosing(CancelEventArgs e)
         {
-            if (currentFile != null)
+            if (currentFile != null && this._saved == false)
             {
                 MessageBoxResult result = MessageBox.Show("Do you want to save before quitting?", "Warning", MessageBoxButton.YesNoCancel);
                 if (result == MessageBoxResult.Yes)


### PR DESCRIPTION
Puts an asterisk in form title when the currently open file has unsaved changes. Asterisk is not displayed if changes are made to a subfile.